### PR TITLE
Prettifies HTML

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@storybook/addons": "5.0.11",
     "@storybook/components": "5.0.11",
     "@storybook/core-events": "5.0.11",
+    "pretty": "^2.0.0",
     "prismjs": "^1.16.0"
   },
   "devDependencies": {

--- a/src/withStaticMarkup.js
+++ b/src/withStaticMarkup.js
@@ -2,12 +2,13 @@ import React from 'react'
 import addons, { makeDecorator } from '@storybook/addons'
 
 import ReactDOMServer from 'react-dom/server'
+import pretty from 'pretty'
 
 class ShowStaticMarkup extends React.Component {
   render () {
     const { children } = this.props
 
-    const markup = ReactDOMServer.renderToStaticMarkup(children)
+    const markup = pretty(ReactDOMServer.renderToStaticMarkup(children), {ocd: true})
     const channel = addons.getChannel()
 
     channel.emit('staticmarkup/markup', markup)


### PR DESCRIPTION
Found your package searching for this exact solution. My only desire was to have better formatted HTML in the tab. This PR reflects that update:

Adds the [pretty](https://www.npmjs.com/package/pretty) package as a dependency and utilizes it in `withStaticMarkup.js` to ensure whitespace, line length, etc., in the compiled HTML are respected when displayed in the Static Markup tab.