### PR TITLE
BUGFIX: fixes TypeError: .replace() is not a function err in console

### DIFF
--- a/src/register.js
+++ b/src/register.js
@@ -154,7 +154,7 @@ class StaticMarkupPanel extends React.Component {
     markup: null
   }
   onReceivedMarkup = markup => {
-    const highlightedMarkup = Prism.highlight(markup, Prism.languages.markup, 'markup')
+    const highlightedMarkup = Prism.highlight(markup.toString(), Prism.languages.markup, 'markup')
     this.setState({
       markup: highlightedMarkup
     })


### PR DESCRIPTION
When using `storybook-react-to-static-markup` in our Storybook projects we noticed we got this ugly error:
<img width="991" alt="Screen Shot 2021-02-25 at 10 14 25 AM" src="https://user-images.githubusercontent.com/17711922/109197819-5579c780-7752-11eb-951f-62773680c3c4.png">

By adding a `toString()` on the {markup} before passing it into Prism removes this error.

- adds toString() call before passing {markup} to PrismJS